### PR TITLE
Optional Add Interest to Savings Accounts

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -1,5 +1,7 @@
 Config = {}
 
+Config.CalculateSavingsInterest = true
+
 Config.cardTypes = { "visa", "mastercard"}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'

--- a/interest_statements.sql
+++ b/interest_statements.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `interest_statements` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `timestamp` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/main.lua
+++ b/server/main.lua
@@ -29,40 +29,42 @@ CreateThread(function()
 end)
 
 Citizen.CreateThread(function()
-    local shouldCalculate = false
-    local lastTime = exports.oxmysql:executeSync('SELECT * FROM interest_statements ORDER BY id DESC LIMIT 0, 1')
-    if lastTime[1] then
-        local lastCalculate = lastTime[1].timestamp
-        local diff = os.difftime(os.time(), lastCalculate)
-        local twentyFourHours = 24 * 60 * 60
-        if diff > twentyFourHours then
-            shouldCalculate = true
-        end
-    end
-    
-    if shouldCalculate then
-        local interestAccounts = exports.oxmysql:executeSync('SELECT * FROM bank_accounts', {})
-        if interestAccounts then
-            for i,v in pairs(interestAccounts) do
-                if v.account_type == 'Savings' then
-                    local balance = v.amount 
-                    local interestAmount = 2 -- in percent
-                    local interest = balance * (interestAmount / 100);
-                    interest = math.floor(interest)
-                    balance = balance + interest
-                    exports.oxmysql:executeSync('UPDATE `bank_accounts` SET `amount`= ? WHERE record_id = ?', {
-                        balance,
-                        v.record_id
-                    })
-                end
+    if Config.CalculateSavingsInterest then
+        local shouldCalculate = false
+        local lastTime = exports.oxmysql:executeSync('SELECT * FROM interest_statements ORDER BY id DESC LIMIT 0, 1')
+        if lastTime[1] then
+            local lastCalculate = lastTime[1].timestamp
+            local diff = os.difftime(os.time(), lastCalculate)
+            local twentyFourHours = 24 * 60 * 60
+            if diff > twentyFourHours then
+                shouldCalculate = true
             end
         end
-        -- UPDATE CURRENT TIME
-        exports.oxmysql:execute('INSERT INTO interest_statements (timestamp) VALUES (?)', {
-            os.time()
-        })
+        
+        if shouldCalculate then
+            local interestAccounts = exports.oxmysql:executeSync('SELECT * FROM bank_accounts', {})
+            if interestAccounts then
+                for i,v in pairs(interestAccounts) do
+                    if v.account_type == 'Savings' then
+                        local balance = v.amount 
+                        local interestAmount = 2 -- in percent
+                        local interest = balance * (interestAmount / 100);
+                        interest = math.floor(interest)
+                        balance = balance + interest
+                        exports.oxmysql:executeSync('UPDATE `bank_accounts` SET `amount`= ? WHERE record_id = ?', {
+                            balance,
+                            v.record_id
+                        })
+                    end
+                end
+            end
+            -- UPDATE CURRENT TIME
+            exports.oxmysql:execute('INSERT INTO interest_statements (timestamp) VALUES (?)', {
+                os.time()
+            })
+        end
+        Wait(100)
     end
-    Wait(100)
 end)
 
 exports('business', function(acctType, bid)

--- a/server/main.lua
+++ b/server/main.lua
@@ -28,6 +28,43 @@ CreateThread(function()
     end
 end)
 
+Citizen.CreateThread(function()
+    local shouldCalculate = false
+    local lastTime = exports.oxmysql:executeSync('SELECT * FROM interest_statements ORDER BY id DESC LIMIT 0, 1')
+    if lastTime[1] then
+        local lastCalculate = lastTime[1].timestamp
+        local diff = os.difftime(os.time(), lastCalculate)
+        local twentyFourHours = 24 * 60 * 60
+        if diff > twentyFourHours then
+            shouldCalculate = true
+        end
+    end
+    
+    if shouldCalculate then
+        local interestAccounts = exports.oxmysql:executeSync('SELECT * FROM bank_accounts', {})
+        if interestAccounts then
+            for i,v in pairs(interestAccounts) do
+                if v.account_type == 'Savings' then
+                    local balance = v.amount 
+                    local interestAmount = 2 -- in percent
+                    local interest = balance * (interestAmount / 100);
+                    interest = math.floor(interest)
+                    balance = balance + interest
+                    exports.oxmysql:executeSync('UPDATE `bank_accounts` SET `amount`= ? WHERE record_id = ?', {
+                        balance,
+                        v.record_id
+                    })
+                end
+            end
+        end
+        -- UPDATE CURRENT TIME
+        exports.oxmysql:execute('INSERT INTO interest_statements (timestamp) VALUES (?)', {
+            os.time()
+        })
+    end
+    Wait(100)
+end)
+
 exports('business', function(acctType, bid)
     if businessAccounts[acctType] then
         if businessAccounts[acctType][tonumber(bid)] then


### PR DESCRIPTION
If enabled in the config, this will add a percent interest to a user's savings account. 
Percent amount is at server/main.lua:50

NOTE:
This assumes your server does scheduled restarts. When the server starts/when the script starts, it checks
if 24 hours has passed by logging into a database table, and if so, then it will calculate the interest and add it to their account.