### PR TITLE
Fix bank cards logic and UI

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -190,11 +190,6 @@ RegisterNUICallback("savingsDeposit", function(data, cb)
     cb(nil)
 end)
 
-RegisterNUICallback("requestNewCard", function(_, cb)
-    TriggerServerEvent('qb-banking:createNewCard')
-    cb("ok")
-end)
-
 RegisterNUICallback("savingsWithdraw", function(data, cb)
     if tonumber(data.amount) ~= nil and tonumber(data.amount) > 0 then
         TriggerServerEvent('qb-banking:savingsWithdraw', data.amount)
@@ -231,8 +226,8 @@ RegisterNUICallback("unLockCard", function(_, cb)
 end)
 
 RegisterNUICallback("updatePin", function(data, cb)
-    if data.pin ~= nil then
-        TriggerServerEvent('qb-banking:updatePin', data.pin)
+    if data.pin and data.currentBankCard then
+        TriggerServerEvent('qb-banking:updatePin', data.currentBankCard, data.pin)
         cb("ok")
     end
     cb(nil)

--- a/nui/index.html
+++ b/nui/index.html
@@ -509,7 +509,7 @@
                                                 </div>
                                                 <div class="row" id="createNewPin" style="display:none;">
                                                     <div class="col-12">
-                                                        <div class="card bg-light mb-3">
+                                                        <div class="card mb-3" style="background:rgba(51, 51, 51, 0.8); color: white;">
                                                             <div class="card-header">Create a New Pin</div>
                                                             <div class="card-body">
                                                                 <div class="container-fluid">

--- a/nui/qb-banking.js
+++ b/nui/qb-banking.js
@@ -3,6 +3,7 @@ Config.closeKeys = [69, 27];
 Config.ATMTransLimit = 5000;
 var currentLimit = null;
 var clientPin = null;
+var currentBankCard = null;
 
 window.addEventListener("message", function (event) {
     if(event.data.status == "openbank") {
@@ -51,6 +52,7 @@ window.addEventListener("message", function (event) {
             enableSavingsCreator();
         }
         if(event.data.information.cardInformation !== undefined && event.data.information.cardInformation !== null) {
+            currentBankCard = event.data.information.cardInformation;
             $('#cardType').html(event.data.information.cardInformation.type)
             var str = ""+ event.data.information.cardInformation.cardNumber + "";
             var res = str.slice(12);
@@ -132,7 +134,6 @@ function setupSavingsMenu(data, name)
     if (statement2 !== undefined) {
     statement2.sort(dynamicSort("date"));
     $.each(statement2, function (index, statement) {
-        // console.log(index)
         if(statement.deposited == null && statement.deposited == undefined) {
             deposit = "0"
         } else {
@@ -281,7 +282,8 @@ $(function() {
             $("#newPinReqMsgDiv").css({"display":"none"});
             $("#newPinReqMsg").html('')
             $.post('https://qb-banking/updatePin', JSON.stringify({
-                pin: pad(newPin, 4)
+                pin: pad(newPin, 4),
+                currentBankCard
              }));
              $('#newPinNumber').val('');
         } else {
@@ -368,7 +370,7 @@ $(function() {
 
     $("#processCard").click(function() {
         var pinValue = $('#cardPinNumber').val();
-        // console.log(pinValue.replace(/[^0-9]/g,"").length);
+
         if(pinValue !== null && pinValue !== undefined && pinValue.replace(/[^0-9]/g,"").length === 4) {
             $("#pinCreatorError").css({"display":"none"});
             $("#pinCreatorErrorMsg").html('');
@@ -454,17 +456,17 @@ $(function() {
     });
 
     $("#confirmCardRequest").click(function() {
+        // Re-use the card ordering screen to request a new card
+        $("#cardDetails").css({"display":"none"});
+        $("#cardOrdering").css({"display":"block"});
+
+        // Reset the requestNewCard elements back to show existing card
+        $("#requestNewCard3").css({"display":"none"});
         $("#requestNewCard2").css({"display":"none"});
-        $("#requestNewCard3").css({"display":"block"});
+        $("#requestNewCard1").css({"display":"block"});
 
-        $.post('https://qb-banking/requestNewCard', JSON.stringify({
-
-        }));
-
-        setTimeout(function(){
-            $("#requestNewCard3").css({"display":"none"});
-            $("#requestNewCard1").css({"display":"block"});
-         }, 5000);
+        // Reset pin field to empty
+        $('#cardPinNumber').val('');
     });
 
     $("#makeSavingsTransfer").click(function() {

--- a/qb-banking.sql
+++ b/qb-banking.sql
@@ -30,3 +30,15 @@ CREATE TABLE IF NOT EXISTS `bank_statements` (
   KEY `businessid` (`businessid`),
   KEY `gangid` (`gangid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `bank_cards` (
+  `record_id` bigint(255) NOT NULL AUTO_INCREMENT,
+  `citizenid` varchar(50),
+  `cardNumber` varchar(50) DEFAULT NULL,
+  `cardPin` varchar(50) DEFAULT NULL,
+  `cardActive` tinyint(4) DEFAULT 1,
+  `cardLocked` tinyint(4) DEFAULT 0,
+  `cardType` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`citizenid`),
+  KEY `record_id` (`record_id`),
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;

--- a/server/main.lua
+++ b/server/main.lua
@@ -205,16 +205,16 @@ local function addNewBankCard(citizenid, cardNumber, cardPin, cardActive, cardLo
         cardNumber,
         cardPin,
         cardActive,
-        0, -- cardLocked
+        cardLocked,
         cardType
-    }, function(result)
+    }, function(_)
     end)
 end
 
 -- Toggle the lock status of a bank card
 local function toggleBankCardLock(cid, lockStatus)
     MySQL.Async.execute('UPDATE bank_cards SET cardLocked = ? WHERE citizenid = ?', { lockStatus, cid},
-    function(result)
+    function(_)
     end)
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -200,22 +200,19 @@ end
 local function addNewBankCard(citizenid, cardNumber, cardPin, cardActive, cardLocked, cardType)
     -- The use of REPLACE will act just like INSERT if there are no results that match on the citizenid key
     -- If there are existing results, it will replace the item with the new data
-    MySQL.Async.insert('REPLACE INTO bank_cards (`citizenid`, `cardNumber`, `cardPin`, `cardActive`, `cardLocked`, `cardType`) VALUES (?, ?, ?, ?, ?, ?)', {
+    MySQL.insert('REPLACE INTO bank_cards (`citizenid`, `cardNumber`, `cardPin`, `cardActive`, `cardLocked`, `cardType`) VALUES (?, ?, ?, ?, ?, ?)', {
         citizenid,
         cardNumber,
         cardPin,
         cardActive,
         cardLocked,
         cardType
-    }, function(_)
-    end)
+    })
 end
 
 -- Toggle the lock status of a bank card
 local function toggleBankCardLock(cid, lockStatus)
-    MySQL.Async.execute('UPDATE bank_cards SET cardLocked = ? WHERE citizenid = ?', { lockStatus, cid},
-    function(_)
-    end)
+    MySQL.update('UPDATE bank_cards SET cardLocked = ? WHERE citizenid = ?', { lockStatus, cid})
 end
 
 QBCore.Functions.CreateCallback('qb-banking:getBankingInformation', function(source, cb)
@@ -326,7 +323,7 @@ RegisterNetEvent('qb-banking:updatePin', function(currentBankCard, newPin)
         local xPlayer = QBCore.Functions.GetPlayer(src)
         while xPlayer == nil do Wait(0) end
 
-        MySQL.Async.execute('UPDATE bank_cards SET cardPin = ? WHERE record_id = ?', {
+        MySQL.update('UPDATE bank_cards SET cardPin = ? WHERE record_id = ?', {
             newPin,
             currentBankCard.record_id
         }, function(result)

--- a/server/main.lua
+++ b/server/main.lua
@@ -192,7 +192,7 @@ end
 
 -- Get all bank cards for the current player
 local function getBankCard(cid)
-    local bankCard = MySQL.Sync.fetchAll('SELECT * FROM bank_cards WHERE citizenid = ? ORDER BY record_id DESC LIMIT 1', { cid })
+    local bankCard = MySQL.query.await('SELECT * FROM bank_cards WHERE citizenid = ? ORDER BY record_id DESC LIMIT 1', { cid })
     return bankCard[1]
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -67,20 +67,6 @@ exports('gang', function(gid)
     end
 end)
 
-RegisterNetEvent('qb-banking:createNewCard', function()
-    local src = source
-    local xPlayer = QBCore.Functions.GetPlayer(src)
-
-    if xPlayer ~= nil then
-        local cid = xPlayer.PlayerData.citizenid
-        if (cid) then
-            currentAccounts[cid].generateNewCard()
-        end
-    end
-
-    TriggerEvent('qb-log:server:CreateLog', 'banking', 'Banking', 'lightgreen', "**"..GetPlayerName(xPlayer.PlayerData.source) .. " (citizenid: "..xPlayer.PlayerData.citizenid.." | id: "..xPlayer.PlayerData.source..")**" .. " created new card")
-end)
-
 --[[ -- Only used by the following "qb-banking:initiateTransfer"
 
 local function getCharacterName(cid)
@@ -204,16 +190,47 @@ local function format_int(number)
     return minus .. int:reverse():gsub("^,", "") .. fraction
 end
 
+-- Get all bank cards for the current player
+local function getBankCard(cid)
+    local bankCard = MySQL.Sync.fetchAll('SELECT * FROM bank_cards WHERE citizenid = ? ORDER BY record_id DESC LIMIT 1', { cid })
+    return bankCard[1]
+end
+
+-- Adds a new bank card to the database, replaces existing card if it exists
+local function addNewBankCard(citizenid, cardNumber, cardPin, cardActive, cardLocked, cardType)
+    -- The use of REPLACE will act just like INSERT if there are no results that match on the citizenid key
+    -- If there are existing results, it will replace the item with the new data
+    MySQL.Async.insert('REPLACE INTO bank_cards (`citizenid`, `cardNumber`, `cardPin`, `cardActive`, `cardLocked`, `cardType`) VALUES (?, ?, ?, ?, ?, ?)', {
+        citizenid,
+        cardNumber,
+        cardPin,
+        cardActive,
+        0, -- cardLocked
+        cardType
+    }, function(result)
+    end)
+end
+
+-- Toggle the lock status of a bank card
+local function toggleBankCardLock(cid, lockStatus)
+    MySQL.Async.execute('UPDATE bank_cards SET cardLocked = ? WHERE citizenid = ?', { lockStatus, cid},
+    function(result)
+    end)
+end
+
 QBCore.Functions.CreateCallback('qb-banking:getBankingInformation', function(source, cb)
     local src = source
     local xPlayer = QBCore.Functions.GetPlayer(src)
     while xPlayer == nil do Wait(0) end
         if (xPlayer) then
+            local bankCard = getBankCard(xPlayer.PlayerData.citizenid)
+
             local banking = {
                     ['name'] = xPlayer.PlayerData.charinfo.firstname .. ' ' .. xPlayer.PlayerData.charinfo.lastname,
                     ['bankbalance'] = '$'.. format_int(xPlayer.PlayerData.money['bank']),
                     ['cash'] = '$'.. format_int(xPlayer.PlayerData.money['cash']),
                     ['accountinfo'] = xPlayer.PlayerData.charinfo.account,
+                    ['cardInformation'] = bankCard
                 }
                 if savingsAccounts[xPlayer.PlayerData.citizenid] then
                     local cid = xPlayer.PlayerData.citizenid
@@ -229,6 +246,8 @@ QBCore.Functions.CreateCallback('qb-banking:getBankingInformation', function(sou
         end
 end)
 
+-- Creates a new bank card.
+-- If the player already has a card it will replace the existing card with the new one
 RegisterNetEvent('qb-banking:createBankCard', function(pin)
     local src = source
     local xPlayer = QBCore.Functions.GetPlayer(src)
@@ -250,8 +269,10 @@ RegisterNetEvent('qb-banking:createBankCard', function(pin)
         xPlayer.Functions.AddItem('mastercard', 1, nil, info)
     end
 
+    addNewBankCard(cid, cardNumber, info.cardPin, info.cardActive, 0, info.cardType)
+
     TriggerClientEvent('qb-banking:openBankScreen', src)
-    TriggerClientEvent('QBCore:Notify', src, Lang:t('success.debit_card'), 'success')
+    TriggerClientEvent('qb-banking:successAlert', src, Lang:t('success.debit_card'))
 
     TriggerEvent('qb-log:server:CreateLog', 'banking', 'Banking', 'lightgreen', "**"..GetPlayerName(xPlayer.PlayerData.source) .. " (citizenid: "..xPlayer.PlayerData.citizenid.." | id: "..xPlayer.PlayerData.source..")** successfully ordered a debit card")
 end)
@@ -273,12 +294,13 @@ RegisterNetEvent('qb-banking:doQuickDeposit', function(amount)
     end
 end)
 
-RegisterNetEvent('qb-banking:toggleCard', function(_)
+RegisterNetEvent('qb-banking:toggleCard', function(toggle)
     local src = source
     local xPlayer = QBCore.Functions.GetPlayer(src)
 
     while xPlayer == nil do Wait(0) end
-        --_char:Bank():ToggleDebitCard(toggle)
+
+    toggleBankCardLock(xPlayer.PlayerData.citizenid, toggle)
 end)
 
 RegisterNetEvent('qb-banking:doQuickWithdraw', function(amount, _)
@@ -298,15 +320,23 @@ RegisterNetEvent('qb-banking:doQuickWithdraw', function(amount, _)
     end
 end)
 
-RegisterNetEvent('qb-banking:updatePin', function(pin)
-    if pin ~= nil then
+RegisterNetEvent('qb-banking:updatePin', function(currentBankCard, newPin)
+    if newPin ~= nil then
         local src = source
         local xPlayer = QBCore.Functions.GetPlayer(src)
         while xPlayer == nil do Wait(0) end
 
-        --   _char:Bank().UpdateDebitCardPin(pin)
-        TriggerClientEvent('qb-banking:openBankScreen', src)
-        TriggerClientEvent('qb-banking:successAlert', src, Lang:t('success.updated_pin'))
+        MySQL.Async.execute('UPDATE bank_cards SET cardPin = ? WHERE record_id = ?', {
+            newPin,
+            currentBankCard.record_id
+        }, function(result)
+            if result == 1 then
+                TriggerClientEvent('qb-banking:openBankScreen', src)
+                TriggerClientEvent('qb-banking:successAlert', src, Lang:t('success.updated_pin'))
+            else
+                TriggerClientEvent('QBCore:Notify', src, 'Error updating pin', "error")
+            end
+        end)
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
This PR adds the functionality needed for the bank cards section of qb-banking to work properly. Some of this functionality already existed in an incomplete state, this PR ties it all together. With these changes a player will now be able to view their active card in the banking screen. This will allow them to update their pin, lock their card, or request a new card.

- Added `bank_cards` table to the SQL file
- Added helper functions for getBankCard, addNewBankCard, toggleBankCardLock that update the database table.
- The logic assumes that a person can only ever have one active bank card. When the user requests a card for the first time, the new card is generated and then stored in the DB for the given citizenId. If a user requests a new card, the same function is used and it overwrites the database entry with the data for the new card. Note, this does not delete the actual item from the players inventory, so people could still have inactive bank cards in their inventory, only one of which is the active one.
- Additionally updated the request a new card UI to re-use the existing UI pieces for first time requesting a new card, adding a layer of consistency to the UI.
- Updated the UI for set pin to have a dark background instead of a light background

Notes:
- addBankCard makes uses of the SQL `REPLACE` and uses the citizenid as the primary key. The use of REPLACE will act just like INSERT if there are no results that match on the citizenid key. If there are existing results, it will replace the item with the new data
- Deleted `requestNewCard` and `qb-banking:createNewCard` as I am now re-using the same flow as when you get a card for the first time so these functions are now obsolete.

Screenshots:
Card management screen w/ Create a new pin (updated the background of the block from white to the same as other elements)
![image](https://user-images.githubusercontent.com/18689469/171323829-219e513a-7df8-4abd-a09a-909d2f034a15.png)

Card management screen - card locked
![image](https://user-images.githubusercontent.com/18689469/171323862-10fc8d7c-a00d-47fc-8483-fd024db21e8e.png)

Requesting a new card and reusing the get a new card flow
![fivem-request-new-card](https://user-images.githubusercontent.com/18689469/171323967-4880107a-5b72-41de-8346-4945b6ac2528.gif)


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
