### PR TITLE
Fix bank statements

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -24,7 +24,9 @@ local Translations = {
         access_bank_target = "Access Bank",
         access_bank_key = "[E] - Access Bank",
         current_to_savings = "Transfer Current Account to Savings",
-        savings_to_current = "Transfer Savings to Current Account "
+        savings_to_current = "Transfer Savings to Current Account",
+        deposit = "Deposit $%{amount} into Current Account",
+        withdraw = "Withdraw $%{amount} from Current Account",
     },
     command = {
         givecash = "Give cash to player."

--- a/nui/index.html
+++ b/nui/index.html
@@ -35,7 +35,7 @@
                                 <a class="nav-link m-1" id="bankingWithdraw-tab" data-toggle="pill" href="#bankingWithdraw" role="tab" aria-controls="bankingWithdraw" aria-selected="false" style="color: white">Withdrawals</a>
                                 <a class="nav-link m-1" id="bankingDeposit-tab" data-toggle="pill" href="#bankingDeposit" role="tab" aria-controls="bankingDeposit" aria-selected="false" style="color: white">Deposit</a>
                                 <a class="nav-link m-1" id="bankingTransfer-tab" data-toggle="pill" href="#bankingTransfer" role="tab" aria-controls="bankingTransfer" aria-selected="false" style="color: white">Transfer</a>
-                                <!-- <a class="nav-link m-1" id="bankingStatement-tab" data-toggle="pill" href="#bankingStatement" role="tab" aria-controls="bankingStatement" aria-selected="false" style= "color: white">Statement</a> -->
+                                <a class="nav-link m-1" id="bankingStatement-tab" data-toggle="pill" href="#bankingStatement" role="tab" aria-controls="bankingStatement" aria-selected="false" style= "color: white">Statement</a>
                                 <a class="nav-link m-1" id="bankingSavings-tab" style="display:none; color: white;" data-toggle="pill" href="#bankingSavings" role="tab" aria-controls="bankingSavings" aria-selected="false">Savings Account</a>
                                 <a class="nav-link m-1" id="bankingActions-tab" data-toggle="pill" href="#bankingActions" role="tab" aria-controls="bankingActions" aria-selected="false" style="color: white">Account Options</a>
                             </div>

--- a/nui/style.css
+++ b/nui/style.css
@@ -13,7 +13,7 @@ body {
     background: #444444 !important;
     border-radius: 7px;
     min-height: 800px;
-    max-height: 800px;
+    max-height: 810px;
     display: none;
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -221,7 +221,7 @@ local function addBankStatement(cid, accountType, amountDeposited, amountWithdra
         accountBalance,
         time,
         statementDescription
-    }, function(result)
+    }, function(_)
     end)
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -206,14 +206,14 @@ end
 
 -- Get all bank statements for the current player
 local function getBankStatements(cid)
-    local bankStatements = MySQL.Sync.fetchAll('SELECT * FROM bank_statements WHERE citizenid = ? ORDER BY record_id DESC LIMIT 30', { cid })
+    local bankStatements = MySQL.query.await('SELECT * FROM bank_statements WHERE citizenid = ? ORDER BY record_id DESC LIMIT 30', { cid })
     return bankStatements
 end
 
 -- Adds a bank statement to the database
 local function addBankStatement(cid, accountType, amountDeposited, amountWithdrawn, accountBalance, statementDescription)
     local time = os.date("%Y-%m-%d %H:%M:%S")
-    MySQL.Async.insert('INSERT INTO `bank_statements` (`account`, `citizenid`, `deposited`, `withdraw`, `balance`, `date`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?)', {
+    MySQL.insert('INSERT INTO `bank_statements` (`account`, `citizenid`, `deposited`, `withdraw`, `balance`, `date`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?)', {
         accountType,
         cid,
         amountDeposited,
@@ -221,8 +221,7 @@ local function addBankStatement(cid, accountType, amountDeposited, amountWithdra
         accountBalance,
         time,
         statementDescription
-    }, function(_)
-    end)
+    })
 end
 
 QBCore.Functions.CreateCallback('qb-banking:getBankingInformation', function(source, cb)

--- a/server/main.lua
+++ b/server/main.lua
@@ -204,16 +204,40 @@ local function format_int(number)
     return minus .. int:reverse():gsub("^,", "") .. fraction
 end
 
+-- Get all bank statements for the current player
+local function getBankStatements(cid)
+    local bankStatements = MySQL.Sync.fetchAll('SELECT * FROM bank_statements WHERE citizenid = ? ORDER BY record_id DESC LIMIT 30', { cid })
+    return bankStatements
+end
+
+-- Adds a bank statement to the database
+local function addBankStatement(cid, accountType, amountDeposited, amountWithdrawn, accountBalance, statementDescription)
+    local time = os.date("%Y-%m-%d %H:%M:%S")
+    MySQL.Async.insert('INSERT INTO `bank_statements` (`account`, `citizenid`, `deposited`, `withdraw`, `balance`, `date`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?)', {
+        accountType,
+        cid,
+        amountDeposited,
+        amountWithdrawn,
+        accountBalance,
+        time,
+        statementDescription
+    }, function(result)
+    end)
+end
+
 QBCore.Functions.CreateCallback('qb-banking:getBankingInformation', function(source, cb)
     local src = source
     local xPlayer = QBCore.Functions.GetPlayer(src)
     while xPlayer == nil do Wait(0) end
         if (xPlayer) then
+            local bankStatements = getBankStatements(xPlayer.PlayerData.citizenid)
+
             local banking = {
                     ['name'] = xPlayer.PlayerData.charinfo.firstname .. ' ' .. xPlayer.PlayerData.charinfo.lastname,
                     ['bankbalance'] = '$'.. format_int(xPlayer.PlayerData.money['bank']),
                     ['cash'] = '$'.. format_int(xPlayer.PlayerData.money['cash']),
                     ['accountinfo'] = xPlayer.PlayerData.charinfo.account,
+                    ['statement'] = bankStatements,
                 }
                 if savingsAccounts[xPlayer.PlayerData.citizenid] then
                     local cid = xPlayer.PlayerData.citizenid
@@ -265,6 +289,9 @@ RegisterNetEvent('qb-banking:doQuickDeposit', function(amount)
     if tonumber(amount) <= currentCash then
         xPlayer.Functions.RemoveMoney('cash', tonumber(amount), 'banking-quick-depo')
         local bank = xPlayer.Functions.AddMoney('bank', tonumber(amount), 'banking-quick-depo')
+        local newBankBalance = xPlayer.Functions.GetMoney('bank')
+        addBankStatement(xPlayer.PlayerData.citizenid, 'Bank', amount, 0, newBankBalance, Lang:t('info.deposit', {amount = amount}))
+
         if bank then
             TriggerClientEvent('qb-banking:openBankScreen', src)
             TriggerClientEvent('qb-banking:successAlert', src, Lang:t('success.cash_deposit', {value = amount}))
@@ -286,6 +313,8 @@ RegisterNetEvent('qb-banking:doQuickWithdraw', function(amount, _)
     local xPlayer = QBCore.Functions.GetPlayer(src)
     while xPlayer == nil do Wait(0) end
     local currentCash = xPlayer.Functions.GetMoney('bank')
+    local newBankBalance = xPlayer.Functions.GetMoney('bank')
+    addBankStatement(xPlayer.PlayerData.citizenid, 'Bank', 0, amount, newBankBalance, Lang:t('info.withdraw', {amount = amount}))
 
     if tonumber(amount) <= currentCash then
         local cash = xPlayer.Functions.RemoveMoney('bank', tonumber(amount), 'banking-quick-withdraw')


### PR DESCRIPTION
**Describe Pull request**
This PR adds the functionality for the bank statements tab in the bank screen. The majority of this logic already existed and just needed a few functions to do the database reads and writes.

- Added two functions `addBankStatement` and `getBankStatements`
- Uncommented the statements tab from the html, allowing it to render
- Added an extra 10px to the max-height of the container to account for the logoff button spilling out of the container once Statement button is added
- Added two new strings for deposit/withdraw statements

Before (logoff button overflowing container)
![image](https://user-images.githubusercontent.com/18689469/171325812-33827821-018f-4102-809e-f4809f4d6c12.png)

After 
![image](https://user-images.githubusercontent.com/18689469/171325862-ba869719-9bcd-40a7-80d1-55d3f279d502.png)

Statements tab showing deposits / withdraws
![image](https://user-images.githubusercontent.com/18689469/171325907-8f86463b-7c09-4161-811d-bded59f1035a.png)


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
