### PR TITLE
Fix for cardtype display

### DIFF
--- a/nui/qb-banking.js
+++ b/nui/qb-banking.js
@@ -53,7 +53,7 @@ window.addEventListener("message", function (event) {
         }
         if(event.data.information.cardInformation !== undefined && event.data.information.cardInformation !== null) {
             currentBankCard = event.data.information.cardInformation;
-            $('#cardType').html(event.data.information.cardInformation.type)
+            $('#cardType').html(event.data.information.cardInformation.cardType)
             var str = ""+ event.data.information.cardInformation.cardNumber + "";
             var res = str.slice(12);
             var cardNumber = "************" + res;


### PR DESCRIPTION
This fix will show the cardType dynamically based on the type of active card the character is using.

[BUG] - Order new card error - Card type forever showing as Visa. #91

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
