### PR TITLE
Added Clear Ped Tasks

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -56,6 +56,7 @@ end
 -- NUI Callback
 
 RegisterNUICallback('closeApp', function(_, cb)
+    ClearPedTasksImmediately(PlayerPedId())
     SetNuiFocus(false, false)
     cb('ok')
 end)


### PR DESCRIPTION
Implementation of the suggestion https://github.com/qbcore-framework/qb-banking/issues/133. It has been added in client.lua a ClearPedTasksImmediately to ensure no anim is played in loop when exiting the ui.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? no
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
