### PR TITLE
feat: Add offline player account statement support

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -65,9 +65,9 @@ local function CreateGangAccount(accountName, accountBalance)
 end
 exports('CreateGangAccount', CreateGangAccount)
 
-local function CreateBankStatement(playerId, account, amount, reason, statementType, accountType)
-    local Player, citizenid = getPlayerAndCitizenId(playerId)
-    if not Player or not citizenid then return false end
+local function _createBankStatement(Player, account, amount, reason, statementType, accountType)
+    if not Player then return false end
+    local citizenid = Player.PlayerData.citizenid
 
     local newStatement = {
         citizenid = citizenid,
@@ -90,7 +90,18 @@ local function CreateBankStatement(playerId, account, amount, reason, statementT
     if not insertSuccess then return false end
     return true
 end
+
+local function CreateBankStatement(playerId, account, amount, reason, statementType, accountType)
+    local Player, _ = getPlayerAndCitizenId(playerId)
+    return _createBankStatement(Player, account, amount, reason, statementType, accountType)
+end
 exports('CreateBankStatement', CreateBankStatement)
+
+local function CreateCitizenBankStatement(citizenId, amount, reason, statementType)
+    local Player = QBCore.Functions.GetPlayerByCitizenId(citizenId) or QBCore.Functions.GetOfflinePlayerByCitizenId(citizenId)
+    _createBankStatement(Player, 'checking', amount, reason, statementType, 'player')
+end
+exports('CreateCitizenBankStatement', CreateCitizenBankStatement)
 
 local function AddMoney(accountName, amount, reason)
     if not reason then reason = 'External Deposit' end


### PR DESCRIPTION
**Describe Pull request**
Creates a new export `CreateCitizenBankStatement` to enable support for faster online/offline player checking account statements.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
