### PR TITLE
feat: auto create accounts for jobs

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -462,8 +462,15 @@ end)
 
 CreateThread(function()
     local accounts = MySQL.query.await('SELECT * FROM bank_accounts')
+
     for _, account in ipairs(accounts) do
         Accounts[account.account_name] = account
+    end
+
+    for job in pairs(QBCore.Shared.Jobs) do
+        if Accounts[job] == nil then
+            CreateJobAccount(job, 0)
+        end
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
This PR aims to ensure that the bank accounts for jobs exist/get added, as many people fail to understand that the job account needs to exist in `bank_accounts` for the job/society money handling to work. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality?
> No
- Does your code fit the style guidelines?
> Yes
- Does your PR fit the contribution guidelines?
> Yes
