### PR TITLE
fix for allowing your business account ot be negative millions

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -124,6 +124,7 @@ local function RemoveMoney(accountName, amount, reason)
     }
     if Accounts[accountName] then
         local accountToUpdate = Accounts[accountName]
+        if accountToUpdate.account_balance < accountToUpdate.account_balance - amount then return end
         accountToUpdate.account_balance = accountToUpdate.account_balance - amount
         if not Statements[accountName] then Statements[accountName] = {} end
         Statements[accountName][#Statements[accountName] + 1] = newStatement


### PR DESCRIPTION
**Describe Pull request**
There is not if check on RemoveMoney export so any script where you can pay out employees or anything that uses this export would allow someone to write "Give 9999999 to Player" and regardless of how much money is in the account, it will allow it to send the money and leave the society account negative

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
yes

- Does your code fit the style guidelines? [yes/no]
yes
- Does your PR fit the contribution guidelines? [yes/no]
yes
