### PR TITLE
🐛 Fix banking interaction zone

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,6 +1,8 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local zones = {}
 
+local isPlayerInsideBankZone = false
+
 -- Functions
 
 local function OpenBank()
@@ -200,14 +202,14 @@ if not Config.useTarget then
         })
 
         combo:onPlayerInOut(function(isPointInside)
-            if isPointInside then
+            isPlayerInsideBankZone = isPointInside
+            if isPlayerInsideBankZone then
                 exports['qb-core']:DrawText('Open Bank')
                 CreateThread(function()
-                    while isPointInside do
+                    while isPlayerInsideBankZone do
                         Wait(0)
                         if IsControlJustPressed(0, 38) then
                             OpenBank()
-                            break
                         end
                     end
                 end)


### PR DESCRIPTION
## Description
This PR introduces a fix for the following issue https://github.com/qbcore-framework/qb-banking/issues/144.

This problem appears/happens when the resource is configured to not use `qb-target`, but instead uses the zones to determine whether the player can open the bank or not.

This bug occurs, because currently the `while` loop inside the `onPlayerInOut` callback conditions the local variable instead of a global one. This means that when the player leaves, a new event is fired _(new callback function executed)_ which has the `isPointInside` set to `false`, but the previous callback function which is still running the `while` loop is not aware of it, so it continues to run until the player presses `E` for the first time.

I also removed the `break` statement on line 210, since it was causing another issue/bug. This bug is that if you close the banking window, you needed to walk out of the banking zone and back in, if you want to open the window again. If you do not walk out, you still have the `Open Bank` notification, but pressing `E` does nothing. This happens, because the `break` statement breaks the `while` loop _(which ends the listener for `E` key)_ until you walk out of the zone and then back in.

## Questions:
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
- [x] Does your code fit the style guidelines?
- [x] Does your PR fit the contribution guidelines?